### PR TITLE
Issue 10

### DIFF
--- a/templates/lists.twig
+++ b/templates/lists.twig
@@ -21,7 +21,7 @@
   <ul class="tags-list center-text">
      {% for tag in tags %}
       <li style="background-color: {{tag.color}}">
-      <a href="/sort/{{tag.texxt}}">
+      <a href="/sort/{{tag.text}}">
       {{ tag.text }}</a></li>
      {% endfor %}
     </ul>


### PR DESCRIPTION
Correct typo on line 24 of lists.twg:
-  updated link in anchor tag href attribute **from** _/sort/{{**tag.texxt**}}_ **to** /sort/{{**tag.text**}}

- Tested feature by clicking on various tags while on index page and on the detail page of a post.

Fixes #10  