### PR TITLE
Fixed Comment Display on detail page

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -37,6 +37,7 @@ $app->map(['GET', 'POST'], '/blog/{slug}',  function( Request $request, Response
     $comments = Comment::where('blog_id', '=', $blog->id)->get();
     // package up all the information we need for the detail view
     $args['blog'] = $blog;
+    $args['comments'] = $comments; //comments were not being passed through 
 
     $tags = $blog->tags;
     $tag_details = [];


### PR DESCRIPTION
##### description
Fixed the Comment Display on detail page

##### what I did
The comments were not being retrieved so I made sure they are passed so the actual comments are loop through and displayed. 
 