### PR TITLE
Broken links in sort route

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -205,6 +205,7 @@ $app->get('/sort/{tag}', function (Request $request, Response $response, array $
         array_push($to_send,[
             "id" => $blog['id'],
             "title" => $blog['title'],
+            "slug" => $blog['title_slug'],
             "created_at" => $blog['created_at'],
             "tags" => $tag_details
         ]);


### PR DESCRIPTION
The slug was not being sent along with the rest of the blog fields when on the `/sort/` route. I fixed the sort route by adding that slug on line 208 of `routes.php`. To test this, click on a tag to sort by then click on the title of one of the resulting entries. This time it should display the details of that entry rather than a "Page Not Found" error.

This fixes issue #39 

Cheers go @bviengineer for pointing out this error 👍 